### PR TITLE
Update Log.php

### DIFF
--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -31,6 +31,7 @@ class Log
     private $sensitiveXmlTags = NULL;
     private $logFile = '';
     private $logLevel = ANET_LOG_LEVEL;
+    private $sensitiveStringRegexes = NULL;
 	
 	/**
 	* Takes a regex pattern (string) as argument and adds the forward slash delimiter.


### PR DESCRIPTION
fix 
PHP Deprecated:  Creation of dynamic property net\authorize\util\Log::$sensitiveStringRegexes is deprecated in /Users/kaioken/Code/test/authorizepayment/vendor/powersync/authorizenet-sdk-php/lib/net/authorize/util/Log.php on line 366